### PR TITLE
Add standalone voxel sandbox demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,1041 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Voxel Realms - Web Minecraft Clone</title>
+  <style>
+    :root {
+      color-scheme: dark;
+    }
+    * {
+      box-sizing: border-box;
+      user-select: none;
+      -webkit-user-select: none;
+      -webkit-tap-highlight-color: transparent;
+    }
+    html, body {
+      margin: 0;
+      height: 100%;
+      overflow: hidden;
+      font-family: "Press Start 2P", "Segoe UI", sans-serif;
+      background: radial-gradient(circle at top, #6bb5ff 0%, #0a1b33 60%);
+      color: #f5f5f5;
+    }
+    #gameCanvas {
+      width: 100%;
+      height: 100%;
+      display: block;
+      touch-action: none;
+    }
+    #overlay {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      pointer-events: none;
+      display: flex;
+      flex-direction: column;
+      justify-content: space-between;
+      padding: 1.5rem;
+    }
+    #hud {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      gap: 1.5rem;
+    }
+    #instructions {
+      background: rgba(8, 13, 24, 0.7);
+      padding: 0.8rem 1rem;
+      border: 2px solid rgba(255, 255, 255, 0.2);
+      border-radius: 0.75rem;
+      font-size: 0.72rem;
+      line-height: 1.5;
+      max-width: 320px;
+      text-shadow: 0 2px 4px rgba(0, 0, 0, 0.5);
+      pointer-events: auto;
+    }
+    #instructions h1 {
+      margin: 0 0 0.5rem;
+      font-size: 1rem;
+      letter-spacing: 1px;
+      color: #ffef8f;
+    }
+    #minimap {
+      width: 120px;
+      height: 120px;
+      background: rgba(0, 0, 0, 0.5);
+      border: 2px solid rgba(255, 255, 255, 0.2);
+      border-radius: 0.75rem;
+      display: grid;
+      grid-template-columns: repeat(12, 1fr);
+      grid-template-rows: repeat(12, 1fr);
+      overflow: hidden;
+    }
+    #statusBar {
+      display: flex;
+      justify-content: center;
+      align-items: center;
+      gap: 1.5rem;
+      pointer-events: auto;
+    }
+    #timeOfDay {
+      background: rgba(0, 0, 0, 0.4);
+      padding: 0.5rem 1rem;
+      border-radius: 999px;
+      font-size: 0.75rem;
+      border: 2px solid rgba(255, 255, 255, 0.25);
+      letter-spacing: 0.08rem;
+    }
+    #hotbar {
+      display: flex;
+      gap: 0.5rem;
+      background: rgba(8, 13, 24, 0.75);
+      padding: 0.6rem 1rem;
+      border-radius: 1rem;
+      border: 2px solid rgba(255, 255, 255, 0.2);
+    }
+    .hotbar-slot {
+      width: 42px;
+      height: 42px;
+      border: 2px solid rgba(255, 255, 255, 0.25);
+      border-radius: 0.5rem;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      gap: 0.1rem;
+      font-size: 0.65rem;
+      transition: transform 0.2s ease, border-color 0.2s ease;
+    }
+    .hotbar-slot.selected {
+      border-color: #ffe97f;
+      transform: translateY(-6px) scale(1.05);
+      box-shadow: 0 8px 18px rgba(0, 0, 0, 0.35);
+    }
+    .block-preview {
+      width: 24px;
+      height: 24px;
+      border-radius: 0.35rem;
+      border: 1px solid rgba(0, 0, 0, 0.4);
+      box-shadow: inset 0 0 0 2px rgba(255, 255, 255, 0.15);
+    }
+    #crosshair {
+      position: fixed;
+      top: 50%;
+      left: 50%;
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      border: 2px solid rgba(255, 255, 255, 0.5);
+      transform: translate(-50%, -50%);
+      pointer-events: none;
+      box-shadow: 0 0 12px rgba(255, 255, 255, 0.35);
+    }
+    #touchControls {
+      position: fixed;
+      inset: 0;
+      display: none;
+      pointer-events: none;
+    }
+    .joystick {
+      position: absolute;
+      bottom: 1.5rem;
+      width: 140px;
+      height: 140px;
+      border-radius: 50%;
+      background: rgba(0, 0, 0, 0.3);
+      border: 2px solid rgba(255, 255, 255, 0.2);
+      pointer-events: auto;
+      touch-action: none;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+    }
+    .joystick-thumb {
+      width: 70px;
+      height: 70px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.25);
+      border: 2px solid rgba(255, 255, 255, 0.4);
+      transition: transform 0.1s ease;
+      backdrop-filter: blur(4px);
+    }
+    .action-buttons {
+      position: absolute;
+      bottom: 1.5rem;
+      right: 1.5rem;
+      display: flex;
+      gap: 1rem;
+      pointer-events: auto;
+    }
+    .action-buttons button {
+      padding: 0.8rem 1rem;
+      font-size: 0.8rem;
+      border-radius: 0.9rem;
+      border: none;
+      background: rgba(255, 231, 125, 0.85);
+      color: #3a2c09;
+      font-weight: 700;
+      letter-spacing: 1px;
+      box-shadow: 0 6px 14px rgba(0, 0, 0, 0.35);
+      transition: transform 0.1s ease;
+    }
+    .action-buttons button:active {
+      transform: translateY(2px) scale(0.97);
+    }
+    #pointerPrompt {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      background: rgba(3, 6, 13, 0.75);
+      color: #f1f5ff;
+      font-size: 1rem;
+      letter-spacing: 0.08rem;
+      pointer-events: auto;
+      z-index: 5;
+      transition: opacity 0.3s ease;
+    }
+    #pointerPrompt.hidden {
+      opacity: 0;
+      pointer-events: none;
+    }
+    #pointerPrompt div {
+      background: rgba(10, 20, 37, 0.9);
+      padding: 1.2rem 1.5rem;
+      border-radius: 1rem;
+      border: 2px solid rgba(255, 255, 255, 0.2);
+      box-shadow: 0 10px 30px rgba(0, 0, 0, 0.4);
+      text-align: center;
+      max-width: 320px;
+      line-height: 1.6;
+    }
+    #pointerPrompt button {
+      margin-top: 1rem;
+      padding: 0.6rem 1rem;
+      border-radius: 0.7rem;
+      border: none;
+      background: #63c4ff;
+      color: #041021;
+      font-weight: 700;
+      letter-spacing: 0.06rem;
+      cursor: pointer;
+    }
+    @media (max-width: 768px) {
+      #instructions {
+        font-size: 0.65rem;
+        max-width: 260px;
+      }
+      #hud {
+        flex-direction: column;
+        align-items: flex-start;
+      }
+      #minimap {
+        width: 100px;
+        height: 100px;
+      }
+      #timeOfDay {
+        font-size: 0.65rem;
+      }
+    }
+  </style>
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+  <link rel="stylesheet" href="https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap" />
+</head>
+<body>
+  <canvas id="gameCanvas"></canvas>
+  <div id="pointerPrompt">
+    <div>
+      <strong>Voxel Realms</strong>
+      <p>Click or tap to start. Desktop uses mouse + WASD, mobile uses joysticks.</p>
+      <button>Enter World</button>
+    </div>
+  </div>
+  <div id="overlay">
+    <div id="hud">
+      <div id="instructions">
+        <h1>Voxel Realms</h1>
+        <p>Desktop: Click to lock cursor, WASD to move, Space to jump, Shift to sprint. Left click breaks, right click places, scroll to change block.</p>
+        <p>Mobile: Use joysticks, tap buttons to build or mine.</p>
+        <p>Explore rolling hills, forests, shimmering water, and lively critters. A gentle day/night cycle paints the sky.</p>
+      </div>
+      <div id="minimap"></div>
+    </div>
+    <div id="statusBar">
+      <div id="timeOfDay">Dawn</div>
+      <div id="hotbar"></div>
+    </div>
+  </div>
+  <div id="crosshair"></div>
+  <div id="touchControls">
+    <div class="joystick" id="moveJoystick" style="left: 1.5rem;">
+      <div class="joystick-thumb"></div>
+    </div>
+    <div class="joystick" id="lookJoystick" style="right: 1.5rem;">
+      <div class="joystick-thumb"></div>
+    </div>
+    <div class="action-buttons">
+      <button id="breakButton">Break</button>
+      <button id="placeButton">Place</button>
+    </div>
+  </div>
+  <script type="module">
+    import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.160/build/three.module.js";
+    import { PointerLockControls } from "https://cdn.jsdelivr.net/npm/three@0.160/examples/jsm/controls/PointerLockControls.js";
+
+    const canvas = document.getElementById("gameCanvas");
+    const renderer = new THREE.WebGLRenderer({ canvas, antialias: false, alpha: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.outputColorSpace = THREE.SRGBColorSpace;
+
+    const scene = new THREE.Scene();
+    scene.fog = new THREE.FogExp2(0x88b0ff, 0.025);
+
+    const camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.1, 500);
+    camera.position.set(32, 20, 32);
+
+    const clock = new THREE.Clock();
+    const worldSize = 64;
+    const worldDepth = 64;
+    const maxHeight = 24;
+    const blockSize = 1;
+    const playerHeight = 1.6;
+    const playerRadius = 0.35;
+    const gravity = 32;
+    let isMobile = matchMedia("(pointer: coarse)").matches || /Mobi/i.test(navigator.userAgent);
+
+    const ambientLight = new THREE.AmbientLight(0xffffff, 0.6);
+    scene.add(ambientLight);
+    const sunLight = new THREE.DirectionalLight(0xffffff, 0.8);
+    sunLight.position.set(-20, 40, 10);
+    sunLight.castShadow = false;
+    scene.add(sunLight);
+
+    const skyDome = new THREE.Mesh(
+      new THREE.SphereGeometry(200, 24, 16),
+      new THREE.ShaderMaterial({
+        side: THREE.BackSide,
+        uniforms: {
+          topColor: { value: new THREE.Color(0x4d9fff) },
+          bottomColor: { value: new THREE.Color(0xe8f5ff) },
+          offset: { value: 33 },
+          exponent: { value: 0.6 },
+          blend: { value: 0 }
+        },
+        vertexShader: `varying vec3 vWorldPosition;\nvoid main() {\n  vec4 worldPosition = modelMatrix * vec4(position, 1.0);\n  vWorldPosition = worldPosition.xyz;\n  gl_Position = projectionMatrix * modelViewMatrix * vec4(position, 1.0);\n}`,
+        fragmentShader: `uniform vec3 topColor;\nuniform vec3 bottomColor;\nuniform float offset;\nuniform float exponent;\nuniform float blend;\nvarying vec3 vWorldPosition;\nvoid main() {\n  float h = normalize(vWorldPosition + offset).y;\n  float f = max(pow(max(h, 0.0), exponent), 0.0);\n  vec3 day = mix(bottomColor, topColor, f);\n  vec3 night = vec3(0.02, 0.04, 0.1);\n  vec3 col = mix(night, day, blend);\n  gl_FragColor = vec4(col, 1.0);\n}`
+      })
+    );
+    scene.add(skyDome);
+
+    function makePixelTexture(colors, size = 4) {
+      const canvas = document.createElement("canvas");
+      const dimension = size * 4;
+      canvas.width = dimension;
+      canvas.height = dimension;
+      const ctx = canvas.getContext("2d");
+      for (let y = 0; y < dimension; y++) {
+        for (let x = 0; x < dimension; x++) {
+          const color = colors[(x >> 2) % colors.length][(y >> 2) % colors[(x >> 2) % colors.length].length];
+          ctx.fillStyle = color;
+          ctx.fillRect(x, y, 1, 1);
+        }
+      }
+      const texture = new THREE.CanvasTexture(canvas);
+      texture.magFilter = THREE.NearestFilter;
+      texture.minFilter = THREE.NearestMipMapNearestFilter;
+      texture.generateMipmaps = true;
+      return texture;
+    }
+
+    const blockPalette = {
+      grass: { name: "Grass", colors: [["#4c9d3a", "#3a7b2c"], ["#3f842d", "#4e9c3c"]] },
+      dirt: { name: "Dirt", colors: [["#6d4924", "#573818"], ["#5b3f1f", "#704b26"]] },
+      stone: { name: "Stone", colors: [["#888888", "#6f6f6f"], ["#767676", "#8f8f8f"]] },
+      sand: { name: "Sand", colors: [["#d8c97b", "#c1b062"], ["#cdbf70", "#e2d68b"]] },
+      water: { name: "Water", colors: [["#2a5bd7", "#1f47a8"], ["#244fc3", "#1d3f88"]], transparent: true, opacity: 0.65 },
+      wood: { name: "Wood", colors: [["#8a5a2d", "#6d431f"], ["#7b4d25", "#935f31"]] },
+      leaves: { name: "Leaves", colors: [["#3e8f2b", "#2e6a1e"], ["#347523", "#459829"]], transparent: true, opacity: 0.8 },
+      flower: { name: "Flower", colors: [["#f16895", "#db4f7c"], ["#f289a9", "#f5b0c8"]] }
+    };
+
+    const blockTypes = Object.keys(blockPalette);
+    const blockTextures = {};
+    const blockMaterials = {};
+    const blockMeshes = {};
+    const blockCounts = {};
+    const blockMap = new Map();
+    const MAX_BLOCKS = worldSize * worldDepth * maxHeight;
+    const blockGeometry = new THREE.BoxGeometry(blockSize, blockSize, blockSize);
+
+    blockTypes.forEach((type) => {
+      blockTextures[type] = makePixelTexture(blockPalette[type].colors);
+      blockMaterials[type] = new THREE.MeshLambertMaterial({
+        map: blockTextures[type],
+        transparent: !!blockPalette[type].transparent,
+        opacity: blockPalette[type].opacity ?? 1,
+        alphaTest: blockPalette[type].transparent ? 0.3 : 0.0
+      });
+      const mesh = new THREE.InstancedMesh(blockGeometry, blockMaterials[type], MAX_BLOCKS);
+      mesh.instanceMatrix.setUsage(THREE.DynamicDrawUsage);
+      mesh.count = 0;
+      mesh.userData.type = type;
+      blockMeshes[type] = mesh;
+      blockCounts[type] = 0;
+      scene.add(mesh);
+    });
+
+    const perlin = (() => {
+      const permutation = new Uint8Array(512);
+      const p = new Uint8Array(256);
+      for (let i = 0; i < 256; i++) p[i] = i;
+      for (let i = 255; i > 0; i--) {
+        const n = Math.floor(Math.random() * (i + 1));
+        [p[i], p[n]] = [p[n], p[i]];
+      }
+      for (let i = 0; i < 512; i++) permutation[i] = p[i & 255];
+      function fade(t) {
+        return t * t * t * (t * (t * 6 - 15) + 10);
+      }
+      function grad(hash, x, y, z) {
+        const h = hash & 15;
+        const u = h < 8 ? x : y;
+        const v = h < 4 ? y : h === 12 || h === 14 ? x : z;
+        return ((h & 1) === 0 ? u : -u) + ((h & 2) === 0 ? v : -v);
+      }
+      function lerp(t, a, b) {
+        return a + t * (b - a);
+      }
+      return (x, y, z) => {
+        const floorX = Math.floor(x) & 255;
+        const floorY = Math.floor(y) & 255;
+        const floorZ = Math.floor(z) & 255;
+        x -= Math.floor(x);
+        y -= Math.floor(y);
+        z -= Math.floor(z);
+        const u = fade(x);
+        const v = fade(y);
+        const w = fade(z);
+        const A = permutation[floorX] + floorY;
+        const AA = permutation[A] + floorZ;
+        const AB = permutation[A + 1] + floorZ;
+        const B = permutation[floorX + 1] + floorY;
+        const BA = permutation[B] + floorZ;
+        const BB = permutation[B + 1] + floorZ;
+        return lerp(
+          w,
+          lerp(
+            v,
+            lerp(u, grad(permutation[AA], x, y, z), grad(permutation[BA], x - 1, y, z)),
+            lerp(u, grad(permutation[AB], x, y - 1, z), grad(permutation[BB], x - 1, y - 1, z))
+          ),
+          lerp(
+            v,
+            lerp(u, grad(permutation[AA + 1], x, y, z - 1), grad(permutation[BA + 1], x - 1, y, z - 1)),
+            lerp(u, grad(permutation[AB + 1], x, y - 1, z - 1), grad(permutation[BB + 1], x - 1, y - 1, z - 1))
+          )
+        );
+      };
+    })();
+
+    function getKey(x, y, z) {
+      return `${x},${y},${z}`;
+    }
+
+    function setBlock(type, x, y, z) {
+      blockMap.set(getKey(x, y, z), { type });
+    }
+
+    function removeBlock(x, y, z) {
+      blockMap.delete(getKey(x, y, z));
+    }
+
+    function getBlock(x, y, z) {
+      return blockMap.get(getKey(x, y, z));
+    }
+
+    function rebuildWorldMeshes() {
+      Object.values(blockMeshes).forEach((mesh) => {
+        mesh.count = 0;
+      });
+      const tempMatrix = new THREE.Matrix4();
+      const tempPosition = new THREE.Vector3();
+      blockMap.forEach((data, key) => {
+        const [x, y, z] = key.split(",").map(Number);
+        const type = data.type;
+        const mesh = blockMeshes[type];
+        if (!mesh) return;
+        tempPosition.set(x + 0.5, y + 0.5, z + 0.5);
+        tempMatrix.makeTranslation(tempPosition.x, tempPosition.y, tempPosition.z);
+        mesh.setMatrixAt(mesh.count, tempMatrix);
+        mesh.count++;
+      });
+      Object.values(blockMeshes).forEach((mesh) => {
+        mesh.instanceMatrix.needsUpdate = true;
+      });
+      updateMinimap();
+    }
+
+    function generateWorld() {
+      for (let x = 0; x < worldSize; x++) {
+        for (let z = 0; z < worldDepth; z++) {
+          const nx = x / worldSize;
+          const nz = z / worldDepth;
+          const heightBase = perlin(nx * 4, nz * 4, 0) * 8;
+          const heightDetail = perlin(nx * 8 + 20, nz * 8 + 20, 1) * 3;
+          let height = Math.floor(10 + heightBase + heightDetail);
+          height = Math.max(3, Math.min(maxHeight - 2, height));
+          for (let y = 0; y <= height; y++) {
+            if (y === height) {
+              setBlock("grass", x, y, z);
+            } else if (y > height - 3) {
+              setBlock("dirt", x, y, z);
+            } else {
+              setBlock("stone", x, y, z);
+            }
+          }
+          if (height < 7) {
+            for (let y = height + 1; y <= 7; y++) {
+              setBlock("water", x, y, z);
+            }
+          } else if (height < 9) {
+            setBlock("sand", x, height, z);
+          }
+        }
+      }
+      generateTrees();
+      scatterFlowers();
+      rebuildWorldMeshes();
+    }
+
+    function generateTrees() {
+      for (let x = 2; x < worldSize - 2; x++) {
+        for (let z = 2; z < worldDepth - 2; z++) {
+          const chance = perlin(x * 0.2, z * 0.2, 5);
+          if (chance > 0.35 && Math.random() < 0.12) {
+            const y = getHighestSolidBlockY(x, z);
+            if (!y || y < 4) continue;
+            if (getBlock(x, y, z)?.type !== "grass") continue;
+            const height = 4 + Math.floor(Math.random() * 3);
+            for (let trunk = 1; trunk <= height; trunk++) {
+              setBlock("wood", x, y + trunk, z);
+            }
+            const canopyStart = y + height - 1;
+            for (let dx = -2; dx <= 2; dx++) {
+              for (let dy = -1; dy <= 2; dy++) {
+                for (let dz = -2; dz <= 2; dz++) {
+                  const distance = Math.abs(dx) + Math.abs(dy) + Math.abs(dz);
+                  if (distance <= 4 && !(dx === 0 && dy === height && dz === 0)) {
+                    if (!getBlock(x + dx, canopyStart + dy, z + dz) && Math.random() > 0.15) {
+                      setBlock("leaves", x + dx, canopyStart + dy, z + dz);
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+
+    function scatterFlowers() {
+      for (let i = 0; i < 400; i++) {
+        const x = Math.floor(Math.random() * worldSize);
+        const z = Math.floor(Math.random() * worldDepth);
+        const y = getHighestSolidBlockY(x, z);
+        if (y && getBlock(x, y, z)?.type === "grass" && !getBlock(x, y + 1, z)) {
+          setBlock("flower", x, y + 1, z);
+        }
+      }
+    }
+
+    function getHighestSolidBlockY(x, z) {
+      for (let y = maxHeight; y >= 0; y--) {
+        const block = getBlock(x, y, z);
+        if (block && block.type !== "water") {
+          return y;
+        }
+      }
+      return null;
+    }
+
+    generateWorld();
+
+    const controls = new PointerLockControls(camera, document.body);
+    controls.getObject().position.set(32, 20, 32);
+    scene.add(controls.getObject());
+    const pointerPrompt = document.getElementById("pointerPrompt");
+    pointerPrompt.addEventListener("click", () => {
+      if (isMobile) {
+        pointerPrompt.classList.add("hidden");
+        document.getElementById("touchControls").style.display = "block";
+      } else {
+        controls.lock();
+      }
+    });
+
+    controls.addEventListener("lock", () => {
+      pointerPrompt.classList.add("hidden");
+    });
+    controls.addEventListener("unlock", () => {
+      if (!isMobile) pointerPrompt.classList.remove("hidden");
+    });
+
+    const keys = {};
+    const moveState = { forward: 0, backward: 0, left: 0, right: 0, jump: false };
+    document.addEventListener("keydown", (e) => {
+      keys[e.code] = true;
+      if (e.code === "KeyW") moveState.forward = 1;
+      if (e.code === "KeyS") moveState.backward = 1;
+      if (e.code === "KeyA") moveState.left = 1;
+      if (e.code === "KeyD") moveState.right = 1;
+      if (e.code === "Space") moveState.jump = true;
+      if (e.code === "ShiftLeft") sprinting = true;
+    });
+    document.addEventListener("keyup", (e) => {
+      keys[e.code] = false;
+      if (e.code === "KeyW") moveState.forward = 0;
+      if (e.code === "KeyS") moveState.backward = 0;
+      if (e.code === "KeyA") moveState.left = 0;
+      if (e.code === "KeyD") moveState.right = 0;
+      if (e.code === "Space") moveState.jump = false;
+      if (e.code === "ShiftLeft") sprinting = false;
+    });
+
+    const moveJoystick = document.getElementById("moveJoystick");
+    const lookJoystick = document.getElementById("lookJoystick");
+    const moveThumb = moveJoystick.querySelector(".joystick-thumb");
+    const lookThumb = lookJoystick.querySelector(".joystick-thumb");
+    const actionBreak = document.getElementById("breakButton");
+    const actionPlace = document.getElementById("placeButton");
+    let moveTouchId = null;
+    let lookTouchId = null;
+    const joystickRadius = 55;
+    const moveVector = new THREE.Vector2();
+    const lookVector = new THREE.Vector2();
+
+    function resetJoystick(thumb) {
+      thumb.style.transform = `translate3d(0,0,0)`;
+    }
+
+    if (isMobile) {
+      document.getElementById("touchControls").style.display = "block";
+      pointerPrompt.querySelector("button").textContent = "Tap to Begin";
+      pointerPrompt.addEventListener("touchstart", () => {
+        pointerPrompt.classList.add("hidden");
+      }, { passive: true });
+
+      moveJoystick.addEventListener("touchstart", (event) => {
+        const touch = event.changedTouches[0];
+        moveTouchId = touch.identifier;
+        moveVector.set(0, 0);
+      });
+      moveJoystick.addEventListener("touchmove", (event) => {
+        for (const touch of event.changedTouches) {
+          if (touch.identifier === moveTouchId) {
+            const rect = moveJoystick.getBoundingClientRect();
+            const dx = touch.clientX - (rect.left + rect.width / 2);
+            const dy = touch.clientY - (rect.top + rect.height / 2);
+            const clampedX = Math.max(-joystickRadius, Math.min(joystickRadius, dx));
+            const clampedY = Math.max(-joystickRadius, Math.min(joystickRadius, dy));
+            moveVector.set(clampedX / joystickRadius, clampedY / joystickRadius);
+            moveThumb.style.transform = `translate3d(${clampedX * 0.6}px, ${clampedY * 0.6}px, 0)`;
+          }
+        }
+      }, { passive: true });
+      moveJoystick.addEventListener("touchend", (event) => {
+        for (const touch of event.changedTouches) {
+          if (touch.identifier === moveTouchId) {
+            moveVector.set(0, 0);
+            moveTouchId = null;
+            resetJoystick(moveThumb);
+          }
+        }
+      });
+
+      lookJoystick.addEventListener("touchstart", (event) => {
+        const touch = event.changedTouches[0];
+        lookTouchId = touch.identifier;
+        lookVector.set(0, 0);
+      });
+      lookJoystick.addEventListener("touchmove", (event) => {
+        for (const touch of event.changedTouches) {
+          if (touch.identifier === lookTouchId) {
+            const rect = lookJoystick.getBoundingClientRect();
+            const dx = touch.clientX - (rect.left + rect.width / 2);
+            const dy = touch.clientY - (rect.top + rect.height / 2);
+            const clampedX = Math.max(-joystickRadius, Math.min(joystickRadius, dx));
+            const clampedY = Math.max(-joystickRadius, Math.min(joystickRadius, dy));
+            lookVector.set(clampedX / joystickRadius, clampedY / joystickRadius);
+            lookThumb.style.transform = `translate3d(${clampedX * 0.6}px, ${clampedY * 0.6}px, 0)`;
+          }
+        }
+      }, { passive: true });
+      lookJoystick.addEventListener("touchend", (event) => {
+        for (const touch of event.changedTouches) {
+          if (touch.identifier === lookTouchId) {
+            lookVector.set(0, 0);
+            lookTouchId = null;
+            resetJoystick(lookThumb);
+          }
+        }
+      });
+    }
+
+    const hotbar = document.getElementById("hotbar");
+    let selectedBlockIndex = 0;
+
+    blockTypes.forEach((type, index) => {
+      const slot = document.createElement("div");
+      slot.className = "hotbar-slot";
+      slot.dataset.index = index;
+      const preview = document.createElement("div");
+      preview.className = "block-preview";
+      preview.style.background = blockPalette[type].colors[0][0];
+      slot.appendChild(preview);
+      const label = document.createElement("span");
+      label.textContent = blockPalette[type].name;
+      slot.appendChild(label);
+      slot.addEventListener("click", () => {
+        selectedBlockIndex = index;
+        updateHotbarSelection();
+      });
+      hotbar.appendChild(slot);
+    });
+
+    function updateHotbarSelection() {
+      document.querySelectorAll(".hotbar-slot").forEach((slot) => {
+        slot.classList.toggle("selected", Number(slot.dataset.index) === selectedBlockIndex);
+      });
+    }
+
+    updateHotbarSelection();
+
+    document.addEventListener("wheel", (event) => {
+      selectedBlockIndex = (selectedBlockIndex + (event.deltaY > 0 ? 1 : -1) + blockTypes.length) % blockTypes.length;
+      updateHotbarSelection();
+    });
+
+    const placeSound = new Audio("https://cdn.jsdelivr.net/gh/terkelg/awesome-creative-coding-assets/audio/pop.mp3");
+    const breakSound = new Audio("https://cdn.jsdelivr.net/gh/terkelg/awesome-creative-coding-assets/audio/click.mp3");
+
+    const raycaster = new THREE.Raycaster();
+    const pointer = new THREE.Vector2();
+    pointer.set(0, 0);
+
+    let sprinting = false;
+    let velocity = new THREE.Vector3();
+    let canJump = true;
+    let timeOfDay = 0.2;
+    const timeElement = document.getElementById("timeOfDay");
+
+    function updateTimeOfDay(delta) {
+      timeOfDay += delta * 0.02;
+      timeOfDay %= 1;
+      const blend = Math.sin(timeOfDay * Math.PI) * 0.5 + 0.5;
+      skyDome.material.uniforms.blend.value = blend;
+      const daylight = blend;
+      ambientLight.intensity = 0.4 + daylight * 0.5;
+      sunLight.intensity = 0.2 + daylight * 0.8;
+      sunLight.position.set(Math.sin(timeOfDay * Math.PI * 2) * 40, Math.cos(timeOfDay * Math.PI * 2) * 30, 10);
+      const names = ["Dawn", "Morning", "Noon", "Sunset", "Night"];
+      let label = "";
+      if (timeOfDay < 0.2) label = names[0];
+      else if (timeOfDay < 0.35) label = names[1];
+      else if (timeOfDay < 0.55) label = names[2];
+      else if (timeOfDay < 0.75) label = names[3];
+      else label = names[4];
+      timeElement.textContent = label;
+      scene.fog.color.setHSL(0.55, 0.4, 0.5 + daylight * 0.2);
+    }
+
+    const mobs = [];
+    const mobGeometry = new THREE.BoxGeometry(0.8, 0.8, 0.8);
+    const mobMaterial = new THREE.MeshLambertMaterial({ color: 0xffb347 });
+    function spawnMob() {
+      const mesh = new THREE.Mesh(mobGeometry, mobMaterial);
+      mesh.position.set(Math.random() * worldSize, 20, Math.random() * worldDepth);
+      scene.add(mesh);
+      mobs.push({
+        mesh,
+        direction: new THREE.Vector2(Math.random() - 0.5, Math.random() - 0.5).normalize(),
+        speed: 1 + Math.random() * 0.5,
+        bob: Math.random() * Math.PI * 2
+      });
+    }
+    for (let i = 0; i < 12; i++) {
+      spawnMob();
+    }
+
+    function updateMobs(delta) {
+      mobs.forEach((mob) => {
+        mob.bob += delta * 6;
+        const bobHeight = Math.sin(mob.bob) * 0.1;
+        let x = mob.mesh.position.x + mob.direction.x * mob.speed * delta;
+        let z = mob.mesh.position.z + mob.direction.y * mob.speed * delta;
+        if (x < 1 || x > worldSize - 1 || z < 1 || z > worldDepth - 1) {
+          mob.direction.rotateAround(new THREE.Vector2(), Math.PI * 0.6 * (Math.random() > 0.5 ? 1 : -1));
+        } else {
+          const ground = getHighestSolidBlockY(Math.floor(x), Math.floor(z));
+          if (ground) {
+            mob.mesh.position.set(x, ground + 0.5 + bobHeight, z);
+          }
+        }
+        if (Math.random() < 0.005) {
+          mob.direction.rotateAround(new THREE.Vector2(), (Math.random() - 0.5) * Math.PI);
+        }
+      });
+    }
+
+    function getTerrainHeightAt(x, z) {
+      const gx = Math.floor(x);
+      const gz = Math.floor(z);
+      return getHighestSolidBlockY(gx, gz) ?? 0;
+    }
+
+    function handleDesktopMovement(delta) {
+      const speed = sprinting ? 6 : 4;
+      const direction = new THREE.Vector3();
+      if (moveState.forward) direction.z -= 1;
+      if (moveState.backward) direction.z += 1;
+      if (moveState.left) direction.x -= 1;
+      if (moveState.right) direction.x += 1;
+      direction.normalize();
+      const forward = new THREE.Vector3();
+      controls.getDirection(forward);
+      forward.y = 0;
+      forward.normalize();
+      const right = new THREE.Vector3();
+      right.crossVectors(new THREE.Vector3(0, 1, 0), forward).normalize();
+      velocity.x += (forward.x * direction.z + right.x * direction.x) * speed * delta;
+      velocity.z += (forward.z * direction.z + right.z * direction.x) * speed * delta;
+      velocity.x *= 0.88;
+      velocity.z *= 0.88;
+      velocity.y -= gravity * delta;
+      const pos = controls.getObject().position;
+      pos.x += velocity.x * delta;
+      pos.z += velocity.z * delta;
+      const ground = getTerrainHeightAt(pos.x, pos.z) + playerHeight;
+      if (pos.y <= ground) {
+        pos.y = ground;
+        velocity.y = 0;
+        canJump = true;
+      } else {
+        pos.y += velocity.y * delta;
+      }
+      if (moveState.jump && canJump) {
+        velocity.y = 10;
+        canJump = false;
+      }
+    }
+
+    function handleMobileMovement(delta) {
+      const speed = 5;
+      const pos = camera.position;
+      const yaw = camera.rotation.y;
+      const moveX = moveVector.x;
+      const moveY = moveVector.y;
+      const dirX = Math.sin(yaw);
+      const dirZ = Math.cos(yaw);
+      pos.x += (-dirZ * moveX + dirX * moveY) * speed * delta;
+      pos.z += (dirX * moveX + dirZ * moveY) * speed * delta;
+      const ground = getTerrainHeightAt(pos.x, pos.z) + playerHeight;
+      pos.y += velocity.y * delta;
+      velocity.y -= gravity * delta;
+      if (pos.y <= ground) {
+        pos.y = ground;
+        velocity.y = 0;
+        canJump = true;
+      }
+      if (jumping) {
+        velocity.y = 9;
+        jumping = false;
+        canJump = false;
+      }
+      camera.rotation.y -= lookVector.x * delta * 2.5;
+      camera.rotation.x -= lookVector.y * delta * 2.0;
+      camera.rotation.x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, camera.rotation.x));
+    }
+
+    let jumping = false;
+    if (isMobile) {
+      actionBreak.addEventListener("click", () => attemptBreak());
+      actionPlace.addEventListener("click", () => attemptPlace());
+      actionPlace.addEventListener("dblclick", () => {
+        if (canJump) jumping = true;
+      });
+    }
+
+    document.addEventListener("mousedown", (event) => {
+      if (isMobile) return;
+      if (event.button === 0) {
+        attemptBreak();
+      } else if (event.button === 2) {
+        attemptPlace();
+      }
+    });
+    document.addEventListener("contextmenu", (event) => event.preventDefault());
+    document.addEventListener("mouseup", () => {});
+
+    function getTargetBlock() {
+      const origin = isMobile ? camera.position.clone() : controls.getObject().position.clone();
+      const direction = new THREE.Vector3();
+      if (isMobile) {
+        const matrix = new THREE.Matrix4();
+        matrix.extractRotation(camera.matrixWorld);
+        direction.set(0, 0, -1).applyMatrix4(matrix);
+      } else {
+        controls.getDirection(direction);
+      }
+      raycaster.set(origin, direction);
+      raycaster.far = 6;
+      const intersects = raycaster.intersectObjects(Object.values(blockMeshes));
+      if (intersects.length) {
+        return intersects[0];
+      }
+      return null;
+    }
+
+    function attemptBreak() {
+      const intersection = getTargetBlock();
+      if (intersection) {
+        const instanceId = intersection.instanceId;
+        const mesh = intersection.object;
+        const matrix = new THREE.Matrix4();
+        mesh.getMatrixAt(instanceId, matrix);
+        const pos = new THREE.Vector3().setFromMatrixPosition(matrix);
+        const x = Math.floor(pos.x);
+        const y = Math.floor(pos.y);
+        const z = Math.floor(pos.z);
+        removeBlock(x, y, z);
+        rebuildWorldMeshes();
+        breakSound.currentTime = 0;
+        breakSound.play().catch(() => {});
+      }
+    }
+
+    function attemptPlace() {
+      const intersection = getTargetBlock();
+      if (intersection) {
+        const mesh = intersection.object;
+        const instanceId = intersection.instanceId;
+        const matrix = new THREE.Matrix4();
+        mesh.getMatrixAt(instanceId, matrix);
+        const pos = new THREE.Vector3().setFromMatrixPosition(matrix);
+        const normal = intersection.face.normal.clone();
+        normal.applyMatrix3(new THREE.Matrix3().getNormalMatrix(mesh.matrixWorld));
+        const placePosition = pos.clone().addScaledVector(normal, blockSize);
+        const x = Math.floor(placePosition.x);
+        const y = Math.floor(placePosition.y);
+        const z = Math.floor(placePosition.z);
+        if (!getBlock(x, y, z)) {
+          const blockType = blockTypes[selectedBlockIndex];
+          setBlock(blockType, x, y, z);
+          rebuildWorldMeshes();
+          placeSound.currentTime = 0;
+          placeSound.play().catch(() => {});
+        }
+      }
+    }
+
+    function updateMinimap() {
+      const minimap = document.getElementById("minimap");
+      minimap.innerHTML = "";
+      const scale = 5;
+      const displaySize = 12;
+      const half = Math.floor(displaySize / 2);
+      const playerPos = isMobile ? camera.position : controls.getObject().position;
+      for (let dz = -half; dz < half; dz++) {
+        for (let dx = -half; dx < half; dx++) {
+          const cell = document.createElement("div");
+          const gx = Math.floor(playerPos.x) + dx * scale;
+          const gz = Math.floor(playerPos.z) + dz * scale;
+          const gy = getHighestSolidBlockY(gx, gz);
+          if (gy === null) {
+            cell.style.background = "rgba(0,0,0,0.4)";
+          } else {
+            const block = getBlock(gx, gy, gz);
+            const palette = block ? blockPalette[block.type] : null;
+            cell.style.background = palette ? palette.colors[0][0] : "rgba(20,20,20,0.6)";
+          }
+          minimap.appendChild(cell);
+        }
+      }
+    }
+
+    updateMinimap();
+
+    function animate() {
+      requestAnimationFrame(animate);
+      const delta = Math.min(0.05, clock.getDelta());
+      updateTimeOfDay(delta);
+      if (isMobile) {
+        handleMobileMovement(delta);
+      } else if (controls.isLocked) {
+        handleDesktopMovement(delta);
+      }
+      updateMobs(delta);
+      renderer.render(scene, camera);
+    }
+
+    animate();
+
+    window.addEventListener("resize", () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+    document.addEventListener("mousemove", (event) => {
+      if (isMobile) return;
+    });
+
+    document.addEventListener("mousedown", () => {
+      if (!isMobile && !controls.isLocked) controls.lock();
+    });
+
+    document.addEventListener("keydown", (event) => {
+      if (event.code === "Digit1") selectedBlockIndex = 0;
+      if (event.code === "Digit2") selectedBlockIndex = 1;
+      if (event.code === "Digit3") selectedBlockIndex = 2;
+      if (event.code === "Digit4") selectedBlockIndex = 3;
+      if (event.code === "Digit5") selectedBlockIndex = 4;
+      if (event.code === "Digit6") selectedBlockIndex = 5;
+      if (event.code === "Digit7") selectedBlockIndex = 6;
+      if (event.code === "Digit8") selectedBlockIndex = 7;
+      updateHotbarSelection();
+    });
+
+    const starGeometry = new THREE.BufferGeometry();
+    const starCount = 400;
+    const positions = new Float32Array(starCount * 3);
+    for (let i = 0; i < starCount; i++) {
+      const radius = 120 + Math.random() * 40;
+      const theta = Math.random() * Math.PI * 2;
+      const phi = Math.random() * Math.PI;
+      positions[i * 3] = radius * Math.sin(phi) * Math.cos(theta);
+      positions[i * 3 + 1] = radius * Math.cos(phi);
+      positions[i * 3 + 2] = radius * Math.sin(phi) * Math.sin(theta);
+    }
+    starGeometry.setAttribute("position", new THREE.BufferAttribute(positions, 3));
+    const starMaterial = new THREE.PointsMaterial({ color: 0xffffff, size: 1.2, sizeAttenuation: false, transparent: true });
+    const stars = new THREE.Points(starGeometry, starMaterial);
+    scene.add(stars);
+
+    function updateStars() {
+      const nightFactor = 1 - (Math.sin(timeOfDay * Math.PI) * 0.5 + 0.5);
+      starMaterial.opacity = THREE.MathUtils.clamp(nightFactor * 1.5, 0, 1);
+    }
+
+    setInterval(() => {
+      updateStars();
+      updateMinimap();
+    }, 500);
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add a single-page "Voxel Realms" Minecraft-inspired experience with responsive HUD, touch controls, and instanced voxel rendering
- procedurally generate terrain, trees, flowers, water, mobs, and a day/night cycle with sky and starfield shaders
- enable block placement and destruction with synchronized minimap updates and mobile-friendly input methods

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_b_68f3139362648322972bbcf3247879c2