### PR TITLE
Add detailed SVG illustration of game controller

### DIFF
--- a/gamepad.svg
+++ b/gamepad.svg
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 320" width="640" height="320">
+  <defs>
+    <linearGradient id="bodyGradient" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#1f1f24" />
+      <stop offset="50%" stop-color="#2c2c33" />
+      <stop offset="100%" stop-color="#18181d" />
+    </linearGradient>
+    <radialGradient id="highlight" cx="0.5" cy="0.3" r="0.6">
+      <stop offset="0%" stop-color="#4a4a55" stop-opacity="0.8" />
+      <stop offset="60%" stop-color="#2c2c33" stop-opacity="0.2" />
+      <stop offset="100%" stop-color="#141418" stop-opacity="0" />
+    </radialGradient>
+    <filter id="shadow" x="-0.1" y="-0.1" width="1.2" height="1.2">
+      <feDropShadow dx="0" dy="12" stdDeviation="18" flood-color="#000" flood-opacity="0.5" />
+    </filter>
+  </defs>
+  <rect width="640" height="320" rx="24" fill="#0c0c10" />
+  <g filter="url(#shadow)">
+    <path fill="url(#bodyGradient)" stroke="#0e0e14" stroke-width="4" d="M96,136 C88,98 108,64 140,48 L188,28 C214,16 246,18 270,34 L298,54 C312,64 328,64 342,54 L370,34 C394,18 426,16 452,28 L500,48 C532,64 552,98 544,136 C540,156 540,178 544,198 C550,232 536,266 508,284 C492,294 472,296 454,288 L416,270 C394,260 368,262 348,276 L320,294 C310,300 298,300 288,294 L260,276 C240,262 214,260 192,270 L154,288 C136,296 116,294 100,284 C72,266 58,232 64,198 C68,178 68,156 64,136 Z" />
+    <path fill="url(#highlight)" d="M140,68 C160,58 232,38 276,72 C296,88 320,92 344,72 C388,38 460,58 480,68 C510,82 522,122 510,170 C500,210 472,230 442,224 C412,218 382,226 358,244 C330,264 310,270 320,232 C330,194 312,182 320,154 C328,126 310,96 280,98 C250,100 234,128 238,150 C242,172 208,190 190,226 C172,262 126,230 116,198 C102,150 114,82 140,68 Z" opacity="0.35" />
+
+    <!-- center light bar -->
+    <rect x="292" y="128" width="56" height="24" rx="12" fill="#3ab6ff" opacity="0.7" />
+    <rect x="296" y="132" width="48" height="16" rx="8" fill="#8fd9ff" opacity="0.6" />
+
+    <!-- d-pad -->
+    <g transform="translate(174 146)">
+      <path fill="#1a1a1f" stroke="#08080c" stroke-width="3" d="M0,34 C0,24 8,16 18,16 H34 V0 C34,-10 42,-18 52,-18 H70 C80,-18 88,-10 88,0 V16 H104 C114,16 122,24 122,34 V52 C122,62 114,70 104,70 H88 V86 C88,96 80,104 70,104 H52 C42,104 34,96 34,86 V70 H18 C8,70 0,62 0,52 Z" />
+      <circle cx="61" cy="34" r="10" fill="#1f1f24" />
+      <path d="M54,34 H68" stroke="#0f0f14" stroke-width="4" stroke-linecap="round" />
+      <path d="M61,27 V41" stroke="#0f0f14" stroke-width="4" stroke-linecap="round" />
+      <path d="M34,52 H18" stroke="#30303a" stroke-width="6" stroke-linecap="round" opacity="0.6" />
+      <path d="M88,52 H104" stroke="#30303a" stroke-width="6" stroke-linecap="round" opacity="0.6" />
+      <path d="M52,86 V102" stroke="#30303a" stroke-width="6" stroke-linecap="round" opacity="0.6" />
+      <path d="M52,16 V0" stroke="#30303a" stroke-width="6" stroke-linecap="round" opacity="0.6" />
+    </g>
+
+    <!-- left stick -->
+    <g transform="translate(204 88)">
+      <circle cx="0" cy="0" r="54" fill="#111117" stroke="#050507" stroke-width="4" />
+      <circle cx="0" cy="0" r="40" fill="#1f1f27" />
+      <circle cx="0" cy="0" r="26" fill="#2a2a33" />
+      <path d="M-20,-6 Q0,-16 20,-6" fill="none" stroke="#050507" stroke-width="4" stroke-linecap="round" />
+      <path d="M-20,6 Q0,16 20,6" fill="none" stroke="#050507" stroke-width="4" stroke-linecap="round" />
+    </g>
+
+    <!-- right stick -->
+    <g transform="translate(436 176)">
+      <circle cx="0" cy="0" r="54" fill="#111117" stroke="#050507" stroke-width="4" />
+      <circle cx="0" cy="0" r="40" fill="#1f1f27" />
+      <circle cx="0" cy="0" r="26" fill="#2a2a33" />
+      <path d="M-6,-20 Q-16,0 -6,20" fill="none" stroke="#050507" stroke-width="4" stroke-linecap="round" />
+      <path d="M6,-20 Q16,0 6,20" fill="none" stroke="#050507" stroke-width="4" stroke-linecap="round" />
+    </g>
+
+    <!-- face buttons -->
+    <g transform="translate(462 122)">
+      <circle cx="44" cy="-28" r="18" fill="#2b2b39" stroke="#0b0b10" stroke-width="4" />
+      <circle cx="76" cy="4" r="18" fill="#2b2b39" stroke="#0b0b10" stroke-width="4" />
+      <circle cx="44" cy="36" r="18" fill="#2b2b39" stroke="#0b0b10" stroke-width="4" />
+      <circle cx="12" cy="4" r="18" fill="#2b2b39" stroke="#0b0b10" stroke-width="4" />
+      <circle cx="44" cy="-28" r="10" fill="#6fe3ff" opacity="0.8" />
+      <circle cx="76" cy="4" r="10" fill="#8fff8a" opacity="0.8" />
+      <circle cx="44" cy="36" r="10" fill="#ff6f9c" opacity="0.8" />
+      <circle cx="12" cy="4" r="10" fill="#ffdc6f" opacity="0.8" />
+    </g>
+
+    <!-- shoulder buttons -->
+    <g fill="#1a1a22" stroke="#07070a" stroke-width="3">
+      <path d="M150,94 C140,72 158,54 196,42 C214,36 238,34 264,38 C280,40 284,58 268,64 L224,80 C200,90 178,98 150,94 Z" />
+      <path d="M490,94 C518,98 540,90 564,80 L608,64 C624,58 620,40 604,38 C578,34 554,36 536,42 C498,54 480,72 490,94 Z" />
+    </g>
+
+    <!-- touchpad -->
+    <rect x="260" y="70" width="120" height="80" rx="18" fill="#202028" stroke="#09090d" stroke-width="4" />
+    <path d="M284,94 H356" stroke="#2e2e39" stroke-width="3" stroke-dasharray="6 6" stroke-linecap="round" />
+    <path d="M284,126 H356" stroke="#2e2e39" stroke-width="3" stroke-dasharray="6 6" stroke-linecap="round" />
+
+    <!-- start/select buttons -->
+    <rect x="238" y="160" width="28" height="12" rx="6" fill="#1c1c22" stroke="#050507" stroke-width="2" />
+    <rect x="374" y="160" width="28" height="12" rx="6" fill="#1c1c22" stroke="#050507" stroke-width="2" />
+
+    <!-- mic button -->
+    <circle cx="320" cy="192" r="10" fill="#262632" stroke="#0a0a0f" stroke-width="2" />
+    <path d="M316,190 C316,186 318,184 320,184 C322,184 324,186 324,190 V194 C324,198 322,200 320,200 C318,200 316,198 316,194 Z" fill="#4d4d5a" />
+    <path d="M312,194 H328" stroke="#13131a" stroke-width="3" stroke-linecap="round" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a detailed SVG illustration of a modern game controller with layered shading and highlights
- include elements for sticks, buttons, touchpad, and accent lighting to mirror real-world controllers

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916e06d713c8322ad474554978d50cc)