### PR TITLE
Add detailed gamepad SVG illustration

### DIFF
--- a/gamepad.svg
+++ b/gamepad.svg
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 480 300">
+  <defs>
+    <radialGradient id="bodyGradient" cx="50%" cy="35%" r="70%">
+      <stop offset="0%" stop-color="#4f4f58" />
+      <stop offset="45%" stop-color="#3d3e47" />
+      <stop offset="100%" stop-color="#1c1d23" />
+    </radialGradient>
+    <linearGradient id="highlight" x1="0%" y1="0%" x2="0%" y2="100%">
+      <stop offset="0%" stop-color="#ffffff" stop-opacity="0.3" />
+      <stop offset="100%" stop-color="#ffffff" stop-opacity="0" />
+    </linearGradient>
+    <filter id="shadow" x="-20%" y="-20%" width="140%" height="140%">
+      <feDropShadow dx="0" dy="8" stdDeviation="12" flood-color="#000" flood-opacity="0.35" />
+    </filter>
+  </defs>
+
+  <g filter="url(#shadow)">
+    <path d="M85 80c-26 6-47 34-47 62 0 27 19 47 43 59 16 8 34 12 50 27 14 12 24 36 46 38 26 2 46-30 58-60 6-15 9-24 31-24h18c22 0 25 9 31 24 12 30 32 62 58 60 22-2 32-26 46-38 16-15 34-19 50-27 24-12 43-32 43-59 0-28-21-56-47-62-25-5-53 9-78 14-20 4-28-11-40-26-14-17-35-28-58-28h-70c-23 0-44 11-58 28-12 15-20 30-40 26-25-5-53-19-78-14z" fill="url(#bodyGradient)" stroke="#111319" stroke-width="4" />
+    <path d="M122 90c-20 2-38 16-47 34-9 19-7 43 8 59 11 13 31 16 46 23 21 10 30 32 43 48 5 6 11 11 18 11 12 0 23-12 30-24 14-24 23-53 57-53h24c34 0 43 29 57 53 7 12 18 24 30 24 7 0 13-5 18-11 13-16 22-38 43-48 15-7 35-10 46-23 15-16 17-40 8-59-9-18-27-32-47-34-27-3-58 16-84 12-20-3-29-25-41-39-10-11-24-18-39-18h-50c-15 0-29 7-39 18-12 14-21 36-41 39-26 4-57-15-84-12z" fill="url(#highlight)" opacity="0.35" />
+  </g>
+
+  <g fill="#1c1d23" stroke="#07080c" stroke-width="3">
+    <circle cx="170" cy="160" r="38" fill="#22252f" />
+    <circle cx="310" cy="160" r="38" fill="#22252f" />
+  </g>
+  <g>
+    <circle cx="170" cy="160" r="22" fill="#12151b" stroke="#090a0f" stroke-width="2" />
+    <circle cx="310" cy="160" r="22" fill="#12151b" stroke="#090a0f" stroke-width="2" />
+    <circle cx="170" cy="160" r="8" fill="#2c2f3a" />
+    <circle cx="310" cy="160" r="8" fill="#2c2f3a" />
+  </g>
+
+  <g fill="#2a2d36" stroke="#07080c" stroke-width="3">
+    <circle cx="122" cy="138" r="28" />
+    <path d="M122 112v52" stroke-linecap="round" />
+    <path d="M96 138h52" stroke-linecap="round" />
+  </g>
+
+  <g stroke-linecap="round" stroke-width="4">
+    <circle cx="358" cy="128" r="11" fill="#6d0f20" stroke="#210107" />
+    <circle cx="386" cy="156" r="11" fill="#2f430f" stroke="#121f03" />
+    <circle cx="358" cy="184" r="11" fill="#0f2843" stroke="#040c16" />
+    <circle cx="330" cy="156" r="11" fill="#47245e" stroke="#160526" />
+  </g>
+
+  <g fill="#2c2f3a" stroke="#07080c" stroke-width="3">
+    <rect x="218" y="132" width="44" height="20" rx="6" />
+    <rect x="230" y="110" width="20" height="10" rx="4" />
+    <rect x="230" y="170" width="20" height="10" rx="4" />
+  </g>
+
+  <g>
+    <path d="M90 210c-6 10-13 23-9 35 4 15 22 22 35 15 12-6 17-20 19-33" fill="none" stroke="#08090d" stroke-width="6" stroke-linecap="round" />
+    <path d="M390 210c6 10 13 23 9 35-4 15-22 22-35 15-12-6-17-20-19-33" fill="none" stroke="#08090d" stroke-width="6" stroke-linecap="round" />
+  </g>
+
+  <g fill="#0d1017" stroke="#08090d" stroke-width="2">
+    <path d="M150 94c-3-18 7-36 24-43 17-7 37 0 55-1 18 1 38-6 55 1 17 7 27 25 24 43" opacity="0.55" />
+  </g>
+
+  <g fill="#1b1f29" stroke="#06070b" stroke-width="3">
+    <rect x="118" y="96" width="24" height="14" rx="6" />
+    <rect x="338" y="96" width="24" height="14" rx="6" />
+  </g>
+
+  <g fill="#2f3340" stroke="#090a0f" stroke-width="2">
+    <rect x="202" y="92" width="76" height="10" rx="5" />
+    <ellipse cx="240" cy="222" rx="34" ry="12" fill="#10131a" opacity="0.6" />
+  </g>
+</svg>


### PR DESCRIPTION
## Summary
- add a new SVG asset illustrating a realistic game controller with detailed shading and controls

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6916e06d713c8322ad474554978d50cc)