### PR TITLE
Add mobile-friendly Three.js block world demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
-# gpt
+# Mini Block World
+
+A lightweight, mobile-friendly Three.js sandbox inspired by the classic block world look and feel. Tap to lock the view, move with on-screen joysticks (or WASD + mouse on desktop), and jump to scale the voxel terrain.
+
+## Running locally
+Just open `index.html` in any modern browser. Everything is loaded from CDNs, so no build step is required.
+
+## Features
+- Voxel landscape with layered materials reminiscent of grassy, earthy terrain.
+- First-person controls with keyboard + mouse support and twin virtual sticks for touch.
+- Jump and gravity to navigate the blocky world.
+- Minimal HUD with status messages and instructions.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,367 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=no" />
+  <title>Mini Block World</title>
+  <style>
+    * { box-sizing: border-box; }
+    body, html {
+      margin: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      font-family: "Inter", "Segoe UI", sans-serif;
+      background: #4aa3ff;
+      color: #111;
+    }
+
+    #scene-container {
+      position: fixed;
+      inset: 0;
+    }
+
+    canvas { display: block; }
+
+    #hud {
+      position: fixed;
+      inset: 0;
+      display: flex;
+      justify-content: space-between;
+      padding: 1rem;
+      pointer-events: none;
+    }
+
+    .panel {
+      background: rgba(255, 255, 255, 0.8);
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      max-width: 320px;
+      pointer-events: all;
+      box-shadow: 0 12px 40px rgba(0,0,0,0.18);
+      backdrop-filter: blur(6px);
+    }
+
+    h1 {
+      margin: 0 0 0.25rem;
+      font-size: 1.1rem;
+    }
+
+    .panel p { margin: 0.25rem 0; }
+
+    .controls {
+      position: fixed;
+      bottom: 1rem;
+      left: 0;
+      right: 0;
+      display: flex;
+      justify-content: space-between;
+      padding: 0 1rem;
+      pointer-events: none;
+    }
+
+    .stick {
+      width: 120px;
+      height: 120px;
+      border-radius: 60px;
+      border: 2px solid rgba(255,255,255,0.7);
+      background: rgba(255,255,255,0.15);
+      position: relative;
+      pointer-events: all;
+      touch-action: none;
+    }
+
+    .knob {
+      width: 64px;
+      height: 64px;
+      border-radius: 50%;
+      background: rgba(255,255,255,0.9);
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      transform: translate(-50%, -50%);
+      transition: transform 60ms ease-out;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.2);
+    }
+
+    .button {
+      pointer-events: all;
+      touch-action: manipulation;
+      background: rgba(255,255,255,0.95);
+      border: none;
+      border-radius: 12px;
+      padding: 0.75rem 1rem;
+      margin-left: 0.5rem;
+      font-weight: 700;
+      box-shadow: 0 8px 24px rgba(0,0,0,0.18);
+    }
+
+    #status {
+      position: fixed;
+      bottom: 1rem;
+      right: 1rem;
+      background: rgba(0,0,0,0.55);
+      color: #f2f2f2;
+      padding: 0.5rem 0.75rem;
+      border-radius: 10px;
+      font-size: 0.9rem;
+      pointer-events: none;
+      box-shadow: 0 10px 20px rgba(0,0,0,0.35);
+    }
+  </style>
+</head>
+<body>
+  <div id="scene-container"></div>
+  <div id="hud">
+    <div class="panel">
+      <h1>Mini Block World</h1>
+      <p>Tap the world to start. Use the joysticks on mobile or WASD + mouse on desktop.</p>
+      <p>Explore a chunky landscape with a pickaxe-inspired cursor. Jump to climb blocks!</p>
+    </div>
+  </div>
+  <div class="controls">
+    <div id="move-stick" class="stick"><div class="knob"></div></div>
+    <div style="display: flex; align-items: center; gap: 0.5rem;">
+      <button id="jump-btn" class="button">Jump</button>
+      <div id="look-stick" class="stick"><div class="knob"></div></div>
+    </div>
+  </div>
+  <div id="status">Ready</div>
+
+  <script type="importmap">
+    {
+      "imports": {
+        "three": "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js",
+        "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.165.0/examples/jsm/"
+      }
+    }
+  </script>
+  <script type="module">
+    import * as THREE from 'three';
+    import { PointerLockControls } from 'three/addons/controls/PointerLockControls.js';
+
+    const container = document.getElementById('scene-container');
+    const statusEl = document.getElementById('status');
+
+    const renderer = new THREE.WebGLRenderer({ antialias: true });
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.outputEncoding = THREE.sRGBEncoding;
+    renderer.shadowMap.enabled = true;
+    container.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.background = new THREE.Color(0x78c8ff);
+
+    const camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.1, 500);
+    camera.position.set(16, 16, 16);
+
+    const controls = new PointerLockControls(camera, renderer.domElement);
+
+    const hemi = new THREE.HemisphereLight(0xffffff, 0x445566, 0.9);
+    scene.add(hemi);
+
+    const dir = new THREE.DirectionalLight(0xffffff, 0.9);
+    dir.position.set(20, 30, 10);
+    dir.castShadow = true;
+    dir.shadow.mapSize.set(2048, 2048);
+    scene.add(dir);
+
+    const world = new THREE.Group();
+    scene.add(world);
+
+    const blockSize = 1;
+    const worldSize = 32;
+    const halfSize = worldSize / 2;
+    const palette = [0x7ec850, 0x6ab048, 0x4d9b3a, 0xd1b280, 0x9d7650];
+
+    const geometry = new THREE.BoxGeometry(blockSize, blockSize, blockSize);
+    geometry.translate(0, blockSize / 2, 0);
+
+    const materials = palette.map(color => new THREE.MeshStandardMaterial({
+      color,
+      roughness: 0.85,
+      metalness: 0.05
+    }));
+
+    function noise(x, z) {
+      return Math.sin(x * 0.3) * 2 + Math.cos(z * 0.25) * 2 + Math.sin((x + z) * 0.12) * 1.5;
+    }
+
+    function buildWorld() {
+      for (let x = -halfSize; x < halfSize; x++) {
+        for (let z = -halfSize; z < halfSize; z++) {
+          const h = Math.max(1, Math.floor(3 + noise(x, z)));
+          const colorIndex = Math.min(materials.length - 1, Math.max(0, h - 1));
+          for (let y = 0; y < h; y++) {
+            const cube = new THREE.Mesh(geometry, materials[colorIndex]);
+            cube.position.set(x * blockSize, y * blockSize, z * blockSize);
+            cube.castShadow = y > 0;
+            cube.receiveShadow = true;
+            world.add(cube);
+          }
+        }
+      }
+    }
+
+    buildWorld();
+
+    const groundMaterial = new THREE.MeshStandardMaterial({ color: 0x6fa66a, roughness: 1 });
+    const ground = new THREE.Mesh(new THREE.PlaneGeometry(worldSize * 2, worldSize * 2), groundMaterial);
+    ground.rotation.x = -Math.PI / 2;
+    ground.position.y = -0.5;
+    ground.receiveShadow = true;
+    scene.add(ground);
+
+    const reticle = new THREE.Mesh(
+      new THREE.TorusGeometry(0.08, 0.02, 8, 32),
+      new THREE.MeshStandardMaterial({ color: 0xffffff, emissive: 0xcccccc })
+    );
+    reticle.position.set(0, 0, -2);
+    camera.add(reticle);
+    scene.add(camera);
+
+    const velocity = new THREE.Vector3();
+    const direction = new THREE.Vector3();
+    let canJump = false;
+    const keys = { w: false, a: false, s: false, d: false };
+
+    document.addEventListener('keydown', (event) => {
+      if (event.code === 'KeyW') keys.w = true;
+      if (event.code === 'KeyA') keys.a = true;
+      if (event.code === 'KeyS') keys.s = true;
+      if (event.code === 'KeyD') keys.d = true;
+      if (event.code === 'Space') jump();
+    });
+
+    document.addEventListener('keyup', (event) => {
+      if (event.code === 'KeyW') keys.w = false;
+      if (event.code === 'KeyA') keys.a = false;
+      if (event.code === 'KeyS') keys.s = false;
+      if (event.code === 'KeyD') keys.d = false;
+    });
+
+    renderer.domElement.addEventListener('click', () => {
+      controls.lock();
+    });
+
+    controls.addEventListener('lock', () => updateStatus('Pointer lock engaged'));
+    controls.addEventListener('unlock', () => updateStatus('Click to look around'));
+
+    const mobileMove = createStick(document.getElementById('move-stick'));
+    const mobileLook = createStick(document.getElementById('look-stick'));
+    document.getElementById('jump-btn').addEventListener('click', jump);
+
+    function jump() {
+      if (canJump) {
+        velocity.y = 8;
+        canJump = false;
+      }
+    }
+
+    function createStick(el) {
+      const knob = el.querySelector('.knob');
+      let active = false;
+      let origin = { x: 0, y: 0 };
+      let value = { x: 0, y: 0 };
+
+      const reset = () => {
+        active = false;
+        value = { x: 0, y: 0 };
+        knob.style.transform = 'translate(-50%, -50%)';
+      };
+
+      el.addEventListener('touchstart', (e) => {
+        const touch = e.changedTouches[0];
+        origin = { x: touch.clientX, y: touch.clientY };
+        active = true;
+      });
+
+      el.addEventListener('touchmove', (e) => {
+        if (!active) return;
+        const touch = e.changedTouches[0];
+        const dx = touch.clientX - origin.x;
+        const dy = touch.clientY - origin.y;
+        const radius = 50;
+        const dist = Math.min(Math.sqrt(dx * dx + dy * dy), radius);
+        const angle = Math.atan2(dy, dx);
+        value = { x: Math.cos(angle) * dist / radius, y: Math.sin(angle) * dist / radius };
+        knob.style.transform = `translate(calc(-50% + ${value.x * radius}px), calc(-50% + ${value.y * radius}px))`;
+      });
+
+      const end = () => reset();
+      el.addEventListener('touchend', end);
+      el.addEventListener('touchcancel', end);
+
+      return {
+        get x() { return value.x; },
+        get y() { return value.y; }
+      };
+    }
+
+    const clock = new THREE.Clock();
+    const raycaster = new THREE.Raycaster();
+
+    function updateStatus(text) {
+      statusEl.textContent = text;
+    }
+
+    function animate() {
+      requestAnimationFrame(animate);
+
+      const delta = Math.min(clock.getDelta(), 0.05);
+      const moveX = (keys.a ? -1 : 0) + (keys.d ? 1 : 0) + mobileMove.x;
+      const moveZ = (keys.w ? -1 : 0) + (keys.s ? 1 : 0) + mobileMove.y;
+
+      direction.set(moveX, 0, moveZ).normalize();
+      if (mobileLook.x !== 0 || mobileLook.y !== 0) {
+        controls.getObject().rotation.y -= mobileLook.x * 0.04;
+        camera.rotation.x -= mobileLook.y * 0.04;
+        camera.rotation.x = Math.max(-Math.PI / 2, Math.min(Math.PI / 2, camera.rotation.x));
+      }
+
+      velocity.x -= velocity.x * 8.0 * delta;
+      velocity.z -= velocity.z * 8.0 * delta;
+      velocity.y -= 25 * delta;
+
+      if (direction.lengthSq() > 0) {
+        const speed = controls.isLocked ? 16 : 10;
+        velocity.x += direction.x * speed * delta;
+        velocity.z += direction.z * speed * delta;
+      }
+
+      controls.moveRight(velocity.x * delta);
+      controls.moveForward(velocity.z * delta);
+
+      controls.getObject().position.y += velocity.y * delta;
+
+      raycaster.set(controls.getObject().position, new THREE.Vector3(0, -1, 0));
+      const intersections = raycaster.intersectObjects(world.children.concat([ground]), false);
+      const onObject = intersections.some(hit => hit.distance < 1.1);
+
+      if (onObject) {
+        velocity.y = Math.max(0, velocity.y);
+        canJump = true;
+      }
+
+      if (controls.getObject().position.y < 1) {
+        velocity.y = 0;
+        controls.getObject().position.y = 1;
+        canJump = true;
+      }
+
+      renderer.render(scene, camera);
+    }
+
+    animate();
+
+    window.addEventListener('resize', () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+
+    updateStatus('Tap the scene to look around');
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone Three.js-powered block world HTML with voxel terrain, lighting, and HUD
- support desktop pointer lock controls plus twin touch joysticks and jump button for mobile
- document how to run the experience and its key features

## Testing
- not run (not applicable)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_6922bb3737448322b804e3f3b84649f2)