### PR TITLE
Add mobile voxel demo

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,462 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
+  <title>Pocket Voxel</title>
+  <style>
+    :root {
+      --ui-bg: rgba(0, 0, 0, 0.55);
+      --accent: #6abf4b;
+      color-scheme: dark;
+    }
+
+    * {
+      box-sizing: border-box;
+      -webkit-tap-highlight-color: transparent;
+    }
+
+    html,
+    body {
+      margin: 0;
+      width: 100%;
+      height: 100%;
+      overflow: hidden;
+      font-family: "Inter", system-ui, -apple-system, sans-serif;
+      background: #0b0f12;
+    }
+
+    #app {
+      position: relative;
+      width: 100%;
+      height: 100%;
+    }
+
+    canvas {
+      display: block;
+      width: 100%;
+      height: 100%;
+    }
+
+    .hud {
+      position: absolute;
+      inset: 0;
+      pointer-events: none;
+    }
+
+    .panel {
+      position: absolute;
+      top: 12px;
+      left: 12px;
+      padding: 10px 12px;
+      background: var(--ui-bg);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      border-radius: 12px;
+      color: #f0f4f8;
+      font-size: 14px;
+      max-width: min(360px, 65vw);
+      backdrop-filter: blur(6px);
+    }
+
+    .panel h1 {
+      margin: 0 0 6px;
+      font-size: 16px;
+      color: #e7ffcf;
+      letter-spacing: 0.02em;
+    }
+
+    .panel p {
+      margin: 4px 0;
+      line-height: 1.4;
+      color: #d8e2ec;
+    }
+
+    .crosshair {
+      position: absolute;
+      top: 50%;
+      left: 50%;
+      width: 18px;
+      height: 18px;
+      transform: translate(-50%, -50%);
+      pointer-events: none;
+    }
+
+    .crosshair::before,
+    .crosshair::after {
+      content: "";
+      position: absolute;
+      background: #f6fff2;
+      box-shadow: 0 0 6px rgba(255, 255, 255, 0.5);
+    }
+
+    .crosshair::before {
+      width: 2px;
+      height: 100%;
+      left: 50%;
+      top: 0;
+      transform: translateX(-50%);
+    }
+
+    .crosshair::after {
+      height: 2px;
+      width: 100%;
+      top: 50%;
+      left: 0;
+      transform: translateY(-50%);
+    }
+
+    .pad {
+      position: absolute;
+      width: 140px;
+      height: 140px;
+      border-radius: 20px;
+      background: var(--ui-bg);
+      border: 1px solid rgba(255, 255, 255, 0.08);
+      bottom: 20px;
+      pointer-events: auto;
+      touch-action: none;
+      backdrop-filter: blur(6px);
+    }
+
+    .pad.left {
+      left: 20px;
+    }
+
+    .pad.right {
+      right: 20px;
+    }
+
+    .pad .thumb {
+      position: absolute;
+      width: 72px;
+      height: 72px;
+      border-radius: 50%;
+      background: rgba(255, 255, 255, 0.15);
+      border: 1px solid rgba(255, 255, 255, 0.24);
+      left: 50%;
+      top: 50%;
+      transform: translate(-50%, -50%);
+      pointer-events: none;
+      transition: transform 120ms ease;
+    }
+
+    .buttons {
+      position: absolute;
+      bottom: 24px;
+      right: 180px;
+      display: flex;
+      gap: 10px;
+      pointer-events: auto;
+    }
+
+    .btn {
+      width: 64px;
+      height: 64px;
+      border-radius: 14px;
+      background: var(--ui-bg);
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      color: #f0f4f8;
+      font-weight: 700;
+      font-size: 13px;
+      display: grid;
+      place-items: center;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      box-shadow: 0 12px 30px rgba(0, 0, 0, 0.3);
+      backdrop-filter: blur(6px);
+      transition: transform 120ms ease, background 120ms ease;
+      touch-action: manipulation;
+    }
+
+    .btn:active {
+      transform: translateY(2px) scale(0.98);
+      background: rgba(255, 255, 255, 0.08);
+    }
+  </style>
+</head>
+
+<body>
+  <div id="app"></div>
+  <div class="hud">
+    <div class="panel">
+      <h1>Pocket Voxel</h1>
+      <p>拖动左侧虚拟摇杆行走，右侧滑动视角，点击跳跃跨越山丘。键盘支持 WASD / 空格。</p>
+      <p>世界由草方块、砂石与木材组成，块状地形和像素纹理致敬经典风格。</p>
+    </div>
+    <div class="crosshair"></div>
+    <div class="pad left" id="move-pad">
+      <div class="thumb"></div>
+    </div>
+    <div class="pad right" id="look-pad">
+      <div class="thumb"></div>
+    </div>
+    <div class="buttons">
+      <button class="btn" id="jump-btn">Jump</button>
+    </div>
+  </div>
+
+  <script type="module">
+    import * as THREE from "https://cdn.jsdelivr.net/npm/three@0.165.0/build/three.module.js";
+
+    const app = document.getElementById("app");
+    const renderer = new THREE.WebGLRenderer({ antialias: true, alpha: false });
+    renderer.setPixelRatio(Math.min(devicePixelRatio, 2));
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setClearColor(0x79c7ff, 1);
+    app.appendChild(renderer.domElement);
+
+    const scene = new THREE.Scene();
+    scene.fog = new THREE.Fog(0x79c7ff, 30, 160);
+
+    const camera = new THREE.PerspectiveCamera(70, window.innerWidth / window.innerHeight, 0.1, 500);
+    camera.position.set(0, 3, 8);
+
+    const hemi = new THREE.HemisphereLight(0xd0e9ff, 0x4c3a2f, 0.85);
+    hemi.position.set(0, 120, 0);
+    scene.add(hemi);
+
+    const sun = new THREE.DirectionalLight(0xffffff, 0.95);
+    sun.position.set(60, 100, 20);
+    sun.castShadow = false;
+    scene.add(sun);
+
+    const createTexture = (base, detail) => {
+      const size = 64;
+      const canvas = document.createElement("canvas");
+      canvas.width = canvas.height = size;
+      const ctx = canvas.getContext("2d");
+      ctx.fillStyle = base;
+      ctx.fillRect(0, 0, size, size);
+      ctx.fillStyle = detail;
+      for (let i = 0; i < 340; i++) {
+        const x = Math.random() * size;
+        const y = Math.random() * size;
+        const w = 2 + Math.random() * 3;
+        ctx.fillRect(x, y, w, w);
+      }
+      return new THREE.CanvasTexture(canvas);
+    };
+
+    const materials = {
+      grass: new THREE.MeshLambertMaterial({ map: createTexture("#4f8f3c", "#5faa4a") }),
+      dirt: new THREE.MeshLambertMaterial({ map: createTexture("#a4733a", "#c48745") }),
+      sand: new THREE.MeshLambertMaterial({ map: createTexture("#d7c27a", "#e0d19a") }),
+      wood: new THREE.MeshLambertMaterial({ map: createTexture("#7a4b24", "#8d5a2c") }),
+    };
+
+    const blockGeo = new THREE.BoxGeometry(1, 1, 1);
+    const world = new Map();
+
+    const setBlock = (x, y, z, material) => {
+      const key = `${x},${y},${z}`;
+      if (world.has(key)) return;
+      const mesh = new THREE.Mesh(blockGeo, material);
+      mesh.position.set(x + 0.5, y + 0.5, z + 0.5);
+      mesh.castShadow = true;
+      mesh.receiveShadow = true;
+      scene.add(mesh);
+      world.set(key, mesh);
+    };
+
+    const noise2D = (x, z) => {
+      const s = Math.sin(x * 127.1 + z * 311.7) * 43758.5453;
+      return s - Math.floor(s);
+    };
+
+    const buildWorld = () => {
+      const size = 32;
+      for (let x = -size; x < size; x++) {
+        for (let z = -size; z < size; z++) {
+          const height = Math.floor(3 + noise2D(x, z) * 6 + noise2D(x * 0.5, z * 0.5) * 2);
+          for (let y = 0; y <= height; y++) {
+            let mat = materials.dirt;
+            if (y === height) mat = materials.grass;
+            else if (y < 2) mat = materials.sand;
+            setBlock(x, y, z, mat);
+          }
+          if (noise2D(x * 1.2, z * 1.2) > 0.9 && Math.abs(x) + Math.abs(z) > 8) {
+            const trunkHeight = 3 + Math.floor(Math.random() * 3);
+            for (let y = height + 1; y <= height + trunkHeight; y++) {
+              setBlock(x, y, z, materials.wood);
+            }
+            for (let i = -2; i <= 2; i++) {
+              for (let j = -2; j <= 2; j++) {
+                if (Math.abs(i) + Math.abs(j) <= 3) {
+                  setBlock(x + i, height + trunkHeight, z + j, materials.grass);
+                  if (Math.abs(i) + Math.abs(j) <= 1) {
+                    setBlock(x + i, height + trunkHeight + 1, z + j, materials.grass);
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    };
+
+    buildWorld();
+
+    const player = {
+      height: 1.6,
+      pos: new THREE.Vector3(0, 6, 10),
+      vel: new THREE.Vector3(),
+      yaw: 0,
+      pitch: 0,
+      onGround: false,
+    };
+
+    const moveState = { forward: 0, strafe: 0 };
+    const lookState = { dx: 0, dy: 0 };
+
+    const keys = new Set();
+    window.addEventListener("keydown", (e) => {
+      keys.add(e.code);
+    });
+    window.addEventListener("keyup", (e) => {
+      keys.delete(e.code);
+    });
+
+    const movePad = document.getElementById("move-pad");
+    const lookPad = document.getElementById("look-pad");
+
+    const makePad = (pad, onMove) => {
+      const thumb = pad.querySelector(".thumb");
+      let active = false;
+      let center = { x: 0, y: 0 };
+
+      const updateThumb = (dx, dy) => {
+        thumb.style.transform = `translate(calc(-50% + ${dx}px), calc(-50% + ${dy}px))`;
+      };
+
+      const reset = () => {
+        active = false;
+        onMove(0, 0);
+        updateThumb(0, 0);
+      };
+
+      const start = (x, y) => {
+        active = true;
+        const rect = pad.getBoundingClientRect();
+        center = { x: rect.left + rect.width / 2, y: rect.top + rect.height / 2 };
+        move(x, y);
+      };
+
+      const move = (x, y) => {
+        if (!active) return;
+        const maxDist = 44;
+        const dx = x - center.x;
+        const dy = y - center.y;
+        const dist = Math.min(Math.hypot(dx, dy), maxDist);
+        const angle = Math.atan2(dy, dx);
+        const normX = Math.cos(angle) * (dist / maxDist);
+        const normY = Math.sin(angle) * (dist / maxDist);
+        updateThumb(normX * 32, normY * 32);
+        onMove(normX, normY);
+      };
+
+      pad.addEventListener("pointerdown", (e) => {
+        pad.setPointerCapture(e.pointerId);
+        start(e.clientX, e.clientY);
+      });
+      pad.addEventListener("pointermove", (e) => move(e.clientX, e.clientY));
+      pad.addEventListener("pointerup", reset);
+      pad.addEventListener("pointercancel", reset);
+      pad.addEventListener("pointerleave", reset);
+    };
+
+    makePad(movePad, (x, y) => {
+      moveState.forward = -y;
+      moveState.strafe = x;
+    });
+
+    makePad(lookPad, (x, y) => {
+      lookState.dx = x;
+      lookState.dy = y;
+    });
+
+    const clamp = (val, min, max) => Math.max(min, Math.min(max, val));
+
+    const getBlockAt = (x, y, z) => world.get(`${Math.floor(x)},${Math.floor(y)},${Math.floor(z)}`);
+
+    const jumpBtn = document.getElementById("jump-btn");
+    jumpBtn.addEventListener("click", () => {
+      if (player.onGround) {
+        player.vel.y = 5.5;
+        player.onGround = false;
+      }
+    });
+
+    const step = (dt) => {
+      const speed = 6;
+      const friction = player.onGround ? 10 : 2;
+      player.onGround = false;
+
+      const forward = (keys.has("KeyW") ? 1 : 0) - (keys.has("KeyS") ? 1 : 0) + moveState.forward;
+      const strafe = (keys.has("KeyD") ? 1 : 0) - (keys.has("KeyA") ? 1 : 0) + moveState.strafe;
+      const dirLen = Math.hypot(forward, strafe);
+      const normF = dirLen > 0 ? forward / dirLen : 0;
+      const normS = dirLen > 0 ? strafe / dirLen : 0;
+
+      player.yaw += lookState.dx * 0.03;
+      player.pitch = clamp(player.pitch + lookState.dy * 0.02, -1.2, 1.2);
+      lookState.dx *= 0.8;
+      lookState.dy *= 0.8;
+
+      const yaw = player.yaw;
+      const forwardVec = new THREE.Vector3(Math.sin(yaw), 0, Math.cos(yaw));
+      const strafeVec = new THREE.Vector3(Math.cos(yaw), 0, -Math.sin(yaw));
+      const moveVec = forwardVec.multiplyScalar(normF).add(strafeVec.multiplyScalar(normS));
+      player.vel.x += moveVec.x * speed * dt;
+      player.vel.z += moveVec.z * speed * dt;
+
+      player.vel.y -= 12 * dt;
+      player.vel.x -= player.vel.x * friction * dt;
+      player.vel.z -= player.vel.z * friction * dt;
+
+      const next = player.pos.clone().addScaledVector(player.vel, dt);
+      const footY = next.y - player.height;
+
+      const collide = (px, py, pz) => {
+        const block = getBlockAt(px, py, pz);
+        return block !== undefined;
+      };
+
+      if (collide(next.x, footY, next.z)) {
+        player.vel.y = 0;
+        next.y = Math.ceil(footY) + player.height;
+        player.onGround = true;
+      }
+
+      const ahead = getBlockAt(next.x, footY - 0.2, next.z);
+      if (ahead && footY - Math.floor(footY) < 0.3) {
+        next.y += 1;
+      }
+
+      player.pos.copy(next);
+
+      camera.position.copy(player.pos);
+      camera.position.y += 0.1;
+      camera.rotation.order = "YXZ";
+      camera.rotation.y = player.yaw;
+      camera.rotation.x = player.pitch;
+    };
+
+    let last = performance.now();
+    const loop = () => {
+      const now = performance.now();
+      const dt = Math.min((now - last) / 1000, 0.05);
+      last = now;
+      step(dt);
+      renderer.render(scene, camera);
+      requestAnimationFrame(loop);
+    };
+    loop();
+
+    window.addEventListener("resize", () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    });
+  </script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add standalone Pocket Voxel page with Minecraft-inspired visuals
- implement three.js terrain generation, lighting, and block textures
- include mobile-friendly virtual joysticks and jump control for movement

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_b_692d402dacd48322a12afb7ce25e66ea)